### PR TITLE
fix(docs): correct Homebrew install command and CLI usage example

### DIFF
--- a/packages/web/app/features/home/terminal-button.tsx
+++ b/packages/web/app/features/home/terminal-button.tsx
@@ -67,7 +67,7 @@ export function TerminalButton() {
                 </div>
                 <div className="flex flex-col gap-1">
                   <p className="text-zinc-400 text-sm leading-6">Abrí tu terminal y corré el siguiente comando</p>
-                  <code className="text-zinc-300 font-mono text-sm">&gt; brew install @lndgalante/subtis</code>
+                  <code className="text-zinc-300 font-mono text-sm">&gt; brew install subtis</code>
                 </div>
               </div>
               <div className="flex flex-col gap-3 items-start">
@@ -84,7 +84,7 @@ export function TerminalButton() {
                 </div>
                 <div className="flex flex-col gap-1">
                   <p className="text-zinc-400 text-sm leading-6">Abrí tu terminal y corré el siguiente comando</p>
-                  <code className="text-zinc-300 font-mono text-sm">&gt; subtis file "nombre-del-archivo.mp4"</code>
+                  <code className="text-zinc-300 font-mono text-sm">&gt; subtis search "nombre-del-archivo.mp4"</code>
                 </div>
               </div>
             </section>


### PR DESCRIPTION
Fixes #41 

fix(docs): correct Homebrew install command and CLI usage example

- Replace invalid `brew install @lndgalante/subtis` with `brew install subtis`
- Update CLI usage example from `subtis file` to `subtis search`
- Both changes reflect actual Homebrew and CLI behavior

## Description

This PR fixes two documentation issues on the installation sheet:

1. The Homebrew install command was invalid (`brew install @lndgalante/subtis`).  
   Now it uses the correct Homebrew syntax: `brew install subtis`.
2. The CLI usage example previously suggested using `subtis file`, which is not a valid command.
   It is now updated to `subtis search`, which matches the actual CLI implementation.

> Which problem this PR solves

These fixes prevent user confusion and errors when installing or using the CLI, and align the documentation with current behavior on both macOS and Linux.

## Complete

- [x] I've performed a self-reviewed of my code
- [x] I've manually tested the feature in development and production environments
- [x] I've covered different scenarios and edge cases in the code
- [x] I've passed all project tests, and/or added more tests
- [x] I've linted the codebase, removed logs, and add code comments (if needed)
- [x] I've added TODO comments and/or added new Linear tickets (if needed)
